### PR TITLE
Updated PT Links for Winter 2023

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -75,11 +75,11 @@ function App() {
 				/>
 				<Route
 					path='ptsignup'
-					element={<Navigate to='//forms.gle/hHqKT4tX6W1n8VHJ9' />}
+					element={<Navigate to='//forms.gle/2uHLu1FdWZbGyYeW8' />}
 				/>
 				<Route
 					path='ptsignups'
-					element={<Navigate to='//forms.gle/hHqKT4tX6W1n8VHJ9' />}
+					element={<Navigate to='//forms.gle/2uHLu1FdWZbGyYeW8' />}
 				/>
 				{/* <Route
 					path='buy'

--- a/src/app/pages/PT/PT.js
+++ b/src/app/pages/PT/PT.js
@@ -24,16 +24,17 @@ const PT = () => (
 				</Text>
 
 				<Text className='color gray'>
-					Applications can be found{' '}
+					To participate in project teams,{' '}
 					<Text className='color blue'>
 						<a
 							href='https://forms.gle/2uHLu1FdWZbGyYeW8'
 							target='_blank'
 							rel='noopener noreferrer'
 						>
-							here.
+							submit an application
 						</a>
-					</Text>
+					</Text>{' '}
+					by Monday, January 16th 2023 at 11:59 PM PST. 
 				</Text>
 
 				<br />

--- a/src/app/pages/PT/PT.js
+++ b/src/app/pages/PT/PT.js
@@ -19,8 +19,21 @@ const PT = () => (
 				className='flex left slim spaceChildrenSmall'
 				style={{ textAlign: 'left' }}
 			>
-				<Text className='color red'>
-					Project Team applications for Fall 2022 have closed.
+				<Text className='color green'>
+					Project Team applications for Winter 2023 are open.
+				</Text>
+
+				<Text className='color gray'>
+					Applications can be found{' '}
+					<Text className='color blue'>
+						<a
+							href='https://forms.gle/2uHLu1FdWZbGyYeW8'
+							target='_blank'
+							rel='noopener noreferrer'
+						>
+							here.
+						</a>
+					</Text>
 				</Text>
 
 				<br />
@@ -43,7 +56,7 @@ const PT = () => (
 				</Text>
 
 				<Space h='32' />
-				<Text size='L'>Fall 2022 PT schedule</Text>
+				{/* <Text size='L'>Fall 2022 PT schedule</Text>
 				<Text className='color gray'>
 					Week 2 / Oct 6 @ 8 pm - Meet your Team + Plan your Project
 					<br />
@@ -60,7 +73,7 @@ const PT = () => (
 					Week 8 / Nov 17 @ 8 pm
 					<br />
 					Week 9 / Gen Meeting - Demo Day
-				</Text>
+				</Text> */}
 			</div>
 		</Section>
 	</>


### PR DESCRIPTION
### Description

Reopened up PT sign up links and updated pt section

Page preview: (updated)
<img width="1256" alt="Screen Shot 2023-01-09 at 3 35 35 PM" src="https://user-images.githubusercontent.com/8120855/211429371-92c2ffd6-64a8-4b19-b0e1-942e51dfca39.png">


Also commented out schedule from last quarter. Not deleting it just yet in case we want to reuse it
