### PR TITLE
Fix dynamic image loading with `require`

### DIFF
--- a/src/app/pages/About/components/Profile/Profile.js
+++ b/src/app/pages/About/components/Profile/Profile.js
@@ -7,10 +7,7 @@ const Profile = ({ textOnly = false, data }) => (
 		{!textOnly && (
 			<div className={cn.aspect}>
 				<img
-					src={
-						require(`assets/images/board/current/${data.photo}`)
-							.default
-					}
+					src={require(`assets/images/board/current/${data.photo}`)}
 					alt={data.name + ' headshot'}
 				/>
 			</div>

--- a/src/app/pages/Designathons/components/Judges/index.jsx
+++ b/src/app/pages/Designathons/components/Judges/index.jsx
@@ -9,9 +9,9 @@ const Judges = ({ profiles }) => {
 			<Text size='XL'>Judges</Text>
 			<div className='split4 s-judges'>
 				{profiles.map(item => (
-					<div className='flex left top spaceChildrenSmall'>
+					<div key={item.name} className='flex left top spaceChildrenSmall'>
 						<img
-							src={require(`assets/${item.photo}`).default}
+							src={require(`assets/${item.photo}`)}
 							alt={'headshot'}
 							style={{
 								height: 'unset',
@@ -19,7 +19,7 @@ const Judges = ({ profiles }) => {
 								width: '100%',
 								position: 'relative',
 							}}
-						 />
+						/>
 						{/* <Text className="color gray">{item.pronouns}</Text> */}
 						<Text size='L'>{item.name}</Text>
 						<Text>{item.role}</Text>

--- a/src/app/pages/Designathons/components/Workshop/Hosts.jsx
+++ b/src/app/pages/Designathons/components/Workshop/Hosts.jsx
@@ -6,9 +6,9 @@ const Hosts = ({ profiles }) => (
 		<Text size='XL'>Workshop Hosts</Text>
 		<div className='split4'>
 			{profiles.map(item => (
-				<div className='flex left top spaceChildrenSmall'>
+				<div key={item.name} className='flex left top spaceChildrenSmall'>
 					<img
-						src={require(`assets/${item.photo}`).default}
+						src={require(`assets/${item.photo}`)}
 						alt="headshots"
 						style={{
 							height: 'unset',

--- a/src/app/pages/Merch/components/MerchItem/MerchItem.js
+++ b/src/app/pages/Merch/components/MerchItem/MerchItem.js
@@ -9,10 +9,7 @@ const MerchItem = ({ path, ...item }) => (
 		<div className={cn.aspect}>
 			<img
 				className={cn.photo}
-				src={
-					require(`../../../../../assets/images/merch/${path}/${item.photo}`)
-						.default
-				}
+				src={require(`assets/images/merch/${path}/${item.photo}`)}
 				alt={item.name}
 			/>
 		</div>


### PR DESCRIPTION
While updating to react-scripts v5 in 1857452, dynamic image links broke because [with Webpack 5, image paths are no longer specified with `.default`](https://stackoverflow.com/a/65347423).