### PR TITLE
Updated events list with pt demo day

### DIFF
--- a/src/assets/data/events/all.json
+++ b/src/assets/data/events/all.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Project Teams Demo Day",
+    "time": "3/9/2023 6:30 PM",
+    "duration": "90",
+    "type": "Project teams",
+    "desc": "Come out to Project Teams Demo Day and see what your fellow designers have been creating the last 8 weeks! Project Teams is a quarterly program that provides students with design experience in a collaborative setting. Project Teams Demo Day is open to all general Design at UCI members and a great chance for teams to showcase their designs, research, and takeaways from the program!",
+    "place": "TBD",
+    "links": []
+  },
+  {
     "title": "Intro to Adobe Illustrator",
     "time": "2/21/2023 8:00 PM",
     "duration": "120",


### PR DESCRIPTION
### Description
Updated events page to include PT Demo Day announcement and details.

Events Page Preview:


<img width="1016" alt="Screen Shot 2023-03-07 at 4 10 40 PM" src="https://user-images.githubusercontent.com/117495028/223585114-1152ac5d-778d-4d99-9434-e0a6a39beb4f.png">

### Testing
Confirmed that details were correct. Ran code to make sure that it appeared properly on screen.