### PR TITLE
fix: remove unused import

### DIFF
--- a/src/app/pages/Designathons/Designathon24/Designathon24.js
+++ b/src/app/pages/Designathons/Designathon24/Designathon24.js
@@ -1,4 +1,4 @@
-import { Icon, Section } from "app/Symbols";
+import { Section } from "app/Symbols";
 import { Text } from "app/components";
 import EVENTS_2024 from "assets/data/designathon/2024/events.json";
 import WINNERS_2024 from "assets/data/designathon/2024/winners.json";


### PR DESCRIPTION
Should allow the build to run now. Also ran `npm run build` locally to confirm.

<img width="588" alt="Screenshot 2024-02-07 at 3 57 34 PM" src="https://github.com/designatuci/DUCI-website/assets/100006999/4da31443-79ba-4986-8e4a-39ea396576ea">
