### PR TITLE
style: fix faq icons on Safari

### DIFF
--- a/src/app/pages/Designathons/Designathon24/components/FAQ/FAQ.module.scss
+++ b/src/app/pages/Designathons/Designathon24/components/FAQ/FAQ.module.scss
@@ -52,7 +52,6 @@
 			}
 
 			.down_carat {
-				width: fit-content;
 				height: 1rem;
 
 				margin: auto 0;


### PR DESCRIPTION
## Summary
1. `width: fit-content` was messing with the icons on Safari. Removing it resolves the issue.

<img width="1329" alt="Screenshot 2024-04-01 at 3 39 51 PM" src="https://github.com/designatuci/DUCI-website/assets/100006999/18794849-305c-477f-9b57-f36a4cca59ec">
