### PR TITLE
chore: update faq who can attend

### DIFF
--- a/src/app/pages/Designathons/Designathon24/components/FAQ/index.jsx
+++ b/src/app/pages/Designathons/Designathon24/components/FAQ/index.jsx
@@ -34,9 +34,10 @@ const FAQ = () => {
 								q: "Who can attend?",
 								a: (
 									<p>
-										Any undergraduate student within the
-										United States (with an associated
-										institutional email) is able to{" "}
+										Any undergraduate OR graduate student
+										within the United States, with an
+										associated institutional (.edu) email is
+										able to{" "}
 										<a
 											target="_blank"
 											rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
1. Update FAQ according to Jay's request:
`Any undergraduate OR graduate student within the United States, with an associated institutional (.edu) email is able to sign up and attend. If you do not qualify, you will not be allowed to participate in the event.`