### PR TITLE
fix: increase z-index on designathon modals

### DIFF
--- a/src/app/pages/Designathons/Designathon23/components/Profile/Modal/Modal.module.scss
+++ b/src/app/pages/Designathons/Designathon23/components/Profile/Modal/Modal.module.scss
@@ -8,7 +8,7 @@
 	place-content: center;
 	background-color: #00000088;
 	transition: opacity 250ms;
-	z-index: 10;
+	z-index: 1001;
 
 	& > .container {
 		background-color: black;

--- a/src/app/pages/Designathons/Designathon24/components/Speakers/Modal/Modal.module.scss
+++ b/src/app/pages/Designathons/Designathon24/components/Speakers/Modal/Modal.module.scss
@@ -8,7 +8,7 @@
 	place-content: center;
 	background-color: #00000088;
 	transition: opacity 250ms;
-	z-index: 10;
+	z-index: 1001;
 
 	padding-top: 5%;
 	padding-left: 5%;


### PR DESCRIPTION
## Summary
1. Modals had too low of a z-index, causing nav to overlap. Fixed by adjusting z-index to `1001`.

#### before
<img width="1728" alt="Screenshot 2024-05-11 at 12 12 37 PM" src="https://github.com/designatuci/DUCI-website/assets/100006999/93775d38-b8e2-44f1-96f9-3e7b02ade23e">

#### after
![image](https://github.com/designatuci/DUCI-website/assets/100006999/3a76a043-f578-49fa-b3fb-61cb3cd9b295)
