### PR TITLE
feat: close mobile nav onclick

### DIFF
--- a/src/app/components/Nav/Nav.js
+++ b/src/app/components/Nav/Nav.js
@@ -10,9 +10,11 @@ import "./Nav.scss";
 const Nav = () => {
 	const { pathname } = useLocation();
 	const [mobileExpand, setMobileExpand] = useState(false);
+
 	const toggleMobileExpand = () => {
 		setMobileExpand(!mobileExpand);
 	};
+
 	if (pathname === "/designathon22/" || pathname === "/designathon22")
 		return <></>;
 
@@ -122,13 +124,19 @@ const Nav = () => {
 							{ label: "Contact", url: "/contact" },
 							{ label: "Houses", url: "/houses" },
 						].map(({ label, url }) => (
-							<Link key={url} to={url} className="item center">
+							<Link
+								key={url}
+								to={url}
+								className="item center"
+								onClick={toggleMobileExpand}
+							>
 								<Text size="L">{label}</Text>
 							</Link>
 						))}
 						<Link
 							to="/join"
 							className="item center button fill sky"
+							onClick={toggleMobileExpand}
 						>
 							<Text size="L">Join</Text>
 						</Link>

--- a/src/app/components/Nav/Nav.js
+++ b/src/app/components/Nav/Nav.js
@@ -1,4 +1,4 @@
-import { useState, memo } from "react";
+import { useState, memo, useCallback } from "react";
 import { Link, useLocation } from "react-router-dom";
 
 import { Text } from "app/components";
@@ -11,9 +11,9 @@ const Nav = () => {
 	const { pathname } = useLocation();
 	const [mobileExpand, setMobileExpand] = useState(false);
 
-	const toggleMobileExpand = () => {
+	const toggleMobileExpand = useCallback(() => {
 		setMobileExpand(!mobileExpand);
-	};
+	}, [mobileExpand]);
 
 	if (pathname === "/designathon22/" || pathname === "/designathon22")
 		return <></>;


### PR DESCRIPTION
## Summary
1. On mobile, clicking a link in the nav does not currently _also_ close the nav, making for an unintuitive UX
2. This PR makes it so that, on (link) click, the nav will close

Before:
![chrome-capture-2024-4-19](https://github.com/designatuci/DUCI-website/assets/100006999/7bf7b676-504c-414d-a0fc-906d6da01432)

After:
![chrome-capture-2024-4-19 (1)](https://github.com/designatuci/DUCI-website/assets/100006999/f5918a55-7eb2-493b-8e13-24ed96a76135)